### PR TITLE
Fix linker error with overlapping .ARM.exidx and .data sections

### DIFF
--- a/linker/stm32f4-flasher.ld
+++ b/linker/stm32f4-flasher.ld
@@ -55,6 +55,14 @@ SECTIONS
                 *(.rodata*)     /* Read-only data */
                 KEEP (*(.config))
                 . = ALIGN(4);
+        } >rom
+
+        /* ARM exception unwinding section */
+        .ARM.exidx : {
+                __exidx_start = .;
+                *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+                __exidx_end = .;
+                . = ALIGN(4);
                 _etext = .;
         } >rom
 

--- a/linker/stm32f4-flasher16.ld
+++ b/linker/stm32f4-flasher16.ld
@@ -55,6 +55,14 @@ SECTIONS
                 *(.rodata*)     /* Read-only data */
                 KEEP (*(.config))
                 . = ALIGN(4);
+        } >rom
+
+        /* ARM exception unwinding section */
+        .ARM.exidx : {
+                __exidx_start = .;
+                *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+                __exidx_end = .;
+                . = ALIGN(4);
                 _etext = .;
         } >rom
 


### PR DESCRIPTION
## Issue

The build was failing with the following linker error:

```
section .ARM.exidx LMA [0801a0f4,0801a0fb] overlaps section .data LMA [0801a0f4,0801a153]
```

This occurs because the Load Memory Address (LMA) of both sections was overlapping, creating a conflict during the linking process.

## Solution

The solution ensures proper placement of the _etext marker after the .ARM.exidx section. This marker is used as the starting LMA for the .data section, so it needs to be positioned appropriately to avoid overlaps.

The change ensures that:

1. The `.ARM.exidx` section is explicitly placed after the .text section
2. The `_etext` symbol is positioned at the end of `.ARM.exidx`
3. The `.data` section's LMA starts after `.ARM.exidx` ends, preventing the overlap

This fix allows the linker to correctly organize memory sections without conflicts, ensuring proper memory layout for the STM32F target.
